### PR TITLE
Answerモデルのリファクタ

### DIFF
--- a/backend/infrastructures/repository/answer.go
+++ b/backend/infrastructures/repository/answer.go
@@ -2,19 +2,12 @@ package repository
 
 import (
 	"context"
-	"time"
 
 	"google.golang.org/api/iterator"
 
 	"github.com/empelt/web-tech-dojo/infrastructures"
 	"github.com/empelt/web-tech-dojo/models"
 )
-
-type AnswerDocument struct {
-	UserId     string    `firestore:"userId,omitempty"`
-	QuestionId int       `firestore:"questionId,omitempty"`
-	UpdatedAt  time.Time `firestore:"updatedAt,omitempty"`
-}
 
 func NewAnswerRepository(firestore *infrastructures.Firestore) (*AnswerRepository, error) {
 	return &AnswerRepository{
@@ -38,38 +31,15 @@ func (r *AnswerRepository) FindAnswer(ctx context.Context, uid string, qid int) 
 		return nil, err
 	}
 
-	var a AnswerDocument
+	a := models.Answer{}
 	if err = doc.DataTo(&a); err != nil {
 		return nil, err
 	}
-	// 2. Messagesを取得
-	mssItr := doc.Ref.Collection(r.subCollectionName).Documents(ctx)
-	mSnapshots, err := mssItr.GetAll()
-	if err != nil {
-		return nil, err
-	}
-	mss := []models.Message{}
-	for i := 0; i < len(mSnapshots); i++ {
-		var m models.Message
-		mSnapshots[i].DataTo(&m)
-		mss = append(mss, m)
-	}
 
-	return &models.Answer{
-		UserId:     a.UserId,
-		QuestionId: a.QuestionId,
-		Messages:   mss,
-		UpdatedAt:  a.UpdatedAt,
-	}, nil
+	return &a, nil
 }
 
-func (r *AnswerRepository) BulkUpsertAnswer(ctx context.Context, a *models.Answer, mss []models.Message) (string, error) {
-	aDoc := AnswerDocument{
-		UserId:     a.UserId,
-		QuestionId: a.QuestionId,
-		UpdatedAt:  a.UpdatedAt,
-	}
-
+func (r *AnswerRepository) BulkUpsertAnswer(ctx context.Context, a *models.Answer) (string, error) {
 	// 1. 既存データ存在確認
 	itr := r.firestore.Client.Collection(r.collectionName).
 		Where("userId", "==", a.UserId).
@@ -78,15 +48,9 @@ func (r *AnswerRepository) BulkUpsertAnswer(ctx context.Context, a *models.Answe
 	doc, err := itr.Next()
 	if err == iterator.Done {
 		// 2.1 新規作成するケース
-		newDoc, _, err := r.firestore.Client.Collection(r.collectionName).Add(ctx, aDoc)
+		newDoc, _, err := r.firestore.Client.Collection(r.collectionName).Add(ctx, a)
 		if err != nil {
 			return "", err
-		}
-		for i := 0; i < len(mss); i++ {
-			_, _, err := newDoc.Collection(r.subCollectionName).Add(ctx, mss[i])
-			if err != nil {
-				return "", err
-			}
 		}
 		return newDoc.ID, nil
 	}
@@ -95,14 +59,8 @@ func (r *AnswerRepository) BulkUpsertAnswer(ctx context.Context, a *models.Answe
 	}
 
 	// 2.2 既存データがあるケース
-	if _, err := doc.Ref.Set(ctx, aDoc); err != nil {
+	if _, err := doc.Ref.Set(ctx, a); err != nil {
 		return "", nil
-	}
-	for i := 0; i < len(mss); i++ {
-		_, _, err := doc.Ref.Collection(r.subCollectionName).Add(ctx, mss[i])
-		if err != nil {
-			return "", err
-		}
 	}
 	return doc.Ref.ID, nil
 }

--- a/backend/models/answer.go
+++ b/backend/models/answer.go
@@ -12,10 +12,10 @@ import (
 // Messages:     メッセージ
 // updatedAt:    最終更新日時
 type Answer struct {
-	UserId     string
-	QuestionId int
-	Messages   []Message
-	UpdatedAt  time.Time
+	UserId     string    `firestore:"userId,omitempty"`
+	QuestionId int       `firestore:"questionId,omitempty"`
+	Messages   []Message `firestore:"messages,omitempty"`
+	UpdatedAt  time.Time `firestore:"updatedAt,omitempty"`
 }
 
 // メッセージ

--- a/backend/services/answer.go
+++ b/backend/services/answer.go
@@ -66,14 +66,14 @@ func (s *AnswerService) PostQuestionAnswer(ctx context.Context, uid string, qid 
 
 	// 5. データを保存
 	// 5.1 解答と返信を保存
+	m := a.Messages
+	m = append(m, models.CreateMessage(message, true))
+	m = append(m, models.CreateMessage(reply, false))
 	if _, err := s.answerRepository.BulkUpsertAnswer(ctx, &models.Answer{
 		UserId:     a.UserId,
 		QuestionId: a.QuestionId,
-		Messages:   []models.Message{},
+		Messages:   m,
 		UpdatedAt:  time.Now(),
-	}, []models.Message{
-		models.CreateMessage(message, true),
-		models.CreateMessage(reply, false),
 	}); err != nil {
 		return nil, err
 	}

--- a/backend/services/interface.go
+++ b/backend/services/interface.go
@@ -20,7 +20,7 @@ type QuestionRepository interface {
 
 type AnswerRepository interface {
 	FindAnswer(ctx context.Context, uid string, qid int) (*models.Answer, error)
-	BulkUpsertAnswer(ctx context.Context, answer *models.Answer, newMessages []models.Message) (string, error)
+	BulkUpsertAnswer(ctx context.Context, answer *models.Answer) (string, error)
 }
 
 type UserRepository interface {


### PR DESCRIPTION
## Overview
<!-- このPRの目的と概要を簡潔に説明してください。 -->
Answerモデルで、Messagesをサブコレクションとして持っていたが、
https://github.com/empelt/web-tech-dojo/pull/37
により、この構成である必要がなくなったのでただの配列要素として保持するように修正

## Changes
<!-- 具体的な変更点や修正箇所を箇条書きでリストアップしてください。 -->

- サブコレクションとして保持していたAnswerモデルのMessagesをただの配列要素として保持するように修正

## Test
<!-- このPRに関する動作検証の内容の記載とスクリーンショット等を添付してください -->

- 解答送信ができる
- 解答が順番通りに保存される
- 解答を取得できる

## Reference
<!-- 参考資料がある場合は添付してください -->

- 
