### PR TITLE
返答テキストだけ返すように修正

### DIFF
--- a/backend/infrastructures/genai.go
+++ b/backend/infrastructures/genai.go
@@ -2,9 +2,9 @@ package infrastructures
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"os"
+	"strings"
 
 	"cloud.google.com/go/vertexai/genai"
 )
@@ -26,17 +26,20 @@ func NewGenai(ctx context.Context) (*Genai, error) {
 
 func (g *Genai) GenerateContentFromText(ctx context.Context, message string) (string, error) {
 	gemini := g.Client.GenerativeModel(modelName)
-	prompt := genai.Text(message)
 
+	prompt := genai.Text(message)
 	resp, err := gemini.GenerateContent(ctx, prompt)
 	if err != nil {
 		return "", fmt.Errorf("error generating content: %w", err)
 	}
-	// See the JSON response in
-	// https://pkg.go.dev/cloud.google.com/go/vertexai/genai#GenerateContentResponse.
-	rb, err := json.MarshalIndent(resp, "", "  ")
-	if err != nil {
-		return "", fmt.Errorf("json.MarshalIndent: %w", err)
+	if resp.PromptFeedback != nil {
+		return "", fmt.Errorf("generating content is blocked: %s", resp.PromptFeedback.BlockReasonMessage)
 	}
-	return string(rb), nil
+	builder := strings.Builder{}
+	for _, candidate := range resp.Candidates {
+		for _, part := range candidate.Content.Parts {
+			builder.WriteString(fmt.Sprintf("%s\n", part))
+		}
+	}
+	return builder.String(), nil
 }

--- a/backend/services/question.go
+++ b/backend/services/question.go
@@ -39,7 +39,15 @@ func (s *QuestionService) GetQuestion(ctx context.Context, uid string, qid int) 
 	}
 	u, err := s.userService.userRepository.GetUser(ctx, uid)
 	if err != nil {
-		return nil, err
+		if err == models.EntityNotFoundError {
+			u = &models.User{
+				UserId:      uid,
+				QuestionIds: []int{},
+				Progresses:  []models.Progress{},
+			}
+		} else {
+			return nil, err
+		}
 	}
 
 	return &GetQuestionResponse{


### PR DESCRIPTION
## Overview
<!-- このPRの目的と概要を簡潔に説明してください。 -->
gemini APIでかえって来た値をそのまま返していた
テキスト部分だけ返すように修正

## Changes
<!-- 具体的な変更点や修正箇所を箇条書きでリストアップしてください。 -->

- `GenerateContentFromText` を修正
- 問題取得時に `User` データがないと404になる問題を修正

## Test
<!-- このPRに関する動作検証の内容の記載とスクリーンショット等を添付してください -->

- 答えを送信するとテキスト部分だけ帰ってくる

## Reference
<!-- 参考資料がある場合は添付してください -->

- https://pkg.go.dev/cloud.google.com/go/vertexai/genai#GenerateContentResponse
