### PR TITLE
FIX: Authorizationヘッダのタグ名修正

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -52,4 +52,4 @@ main.go → handlers → services → infrastructures の一方通行の package
 | -------------- | ------------------------------ | ------------ | -------------- |
 | PORT           | バックエンドサーバのポート番号 | 8080         |                |
 | GCP_PROJECT_ID | GCP のプロジェクト ID          |              |                |
-| AUTHORIZATION_HEADER_TAG_NAME | ヘッダのAuthorizationのタグ名 | X-Forwarded-Authorization | Authorization |
+| AUTHORIZATION_HEADER_TAG_NAME | ヘッダのAuthorizationのタグ名 | | Authorization |

--- a/backend/README.md
+++ b/backend/README.md
@@ -52,3 +52,4 @@ main.go → handlers → services → infrastructures の一方通行の package
 | -------------- | ------------------------------ | ------------ | -------------- |
 | PORT           | バックエンドサーバのポート番号 | 8080         |                |
 | GCP_PROJECT_ID | GCP のプロジェクト ID          |              |                |
+| AUTHORIZATION_HEADER_TAG_NAME | ヘッダのAuthorizationのタグ名 | X-Forwarded-Authorization | Authorization |

--- a/backend/handlers/answer.go
+++ b/backend/handlers/answer.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"errors"
 	"net/http"
+	"os"
 	"strconv"
 	"strings"
 
@@ -17,7 +18,8 @@ func NewAnswerHandler(as AuthService, cs AnswerService) (*AnswerHandler, error) 
 }
 
 func getIdToken(c echo.Context) string {
-	authorization := echo.Context.Request(c).Header.Get("Authorization")
+	tagName := os.Getenv("AUTHORIZATION_HEADER_TAG_NAME")
+	authorization := echo.Context.Request(c).Header.Get(tagName)
 	return strings.TrimPrefix(authorization, "Bearer ")
 }
 


### PR DESCRIPTION
## Overview
<!-- このPRの目的と概要を簡潔に説明してください。 -->
ローカルでは動作するのに、API Gatewayを挟むとFirebase AuthからのUID取得に失敗する
原因はAPI GatewayがheaderのAuthorizationを書き換えてしまうため
`X-Forwarded-Authorization` に元のAuthorizationの内容が入っている

## Changes
<!-- 具体的な変更点や修正箇所を箇条書きでリストアップしてください。 -->

- ヘッダのタグ名を変更できるように修正

## Test
<!-- このPRに関する動作検証の内容の記載とスクリーンショット等を添付してください -->

- ローカルでUID取得ができること

## Reference
<!-- 参考資料がある場合は添付してください -->

- https://stackoverflow.com/questions/71417602/google-api-gateway-authorization-header-not-forwarded
